### PR TITLE
oops

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const featuredPost = filteredPost[0];
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="me" href="https://mastodon.social/@dynamitegus">Mastodon</link>
+    <link rel="me" href="https://mastodon.social/@dynamitegus"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Removed visible Mastodon link text from the homepage while retaining profile verification via rel=me.
  - Prevents the social handle from appearing as on-page content, keeping the layout cleaner and avoiding duplicate links.

- Style
  - Streamlined presentation by hiding the Mastodon link text, preserving only metadata for verification without impacting user navigation or page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->